### PR TITLE
feat(search): add count/group aggregations for CLI and HTTP search

### DIFF
--- a/cmd/maure/command/search.go
+++ b/cmd/maure/command/search.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"sort"
 
+	"maure/pkg/aggregate"
+	"maure/pkg/document"
 	"maure/pkg/highlight"
 	"maure/pkg/index"
 	"maure/pkg/query"
@@ -16,6 +18,8 @@ type SearchCommand struct {
 	*BaseCommand
 	topN   int
 	output string
+	agg    string
+	group  string
 }
 
 // NewSearchCommand 创建搜索命令。
@@ -29,6 +33,8 @@ func NewSearchCommand() *SearchCommand {
 	cmd.flags = flag.NewFlagSet("search", flag.ContinueOnError)
 	cmd.flags.IntVar(&cmd.topN, "n", 10, "返回结果数量")
 	cmd.flags.StringVar(&cmd.output, "o", "text", "输出格式 (text/json)")
+	cmd.flags.StringVar(&cmd.agg, "agg", "", "聚合函数（支持: count）")
+	cmd.flags.StringVar(&cmd.group, "group", "", "分组方式（如: level 或 time(5m)）")
 	return cmd
 }
 
@@ -84,6 +90,7 @@ func (c *SearchCommand) Execute(args []string, opts GlobalOptions) error {
 	terms := query.ExtractTerms(parsedQuery)
 	highlighter := highlight.NewHighlighter()
 	hits := make([]SearchHit, 0, len(results))
+	docsForAgg := make([]*document.Document, 0, len(results))
 	for _, r := range results {
 		sourceDocID := r.DocID
 		if mappedDocID, ok := docIDMap[r.DocID]; ok {
@@ -94,6 +101,7 @@ func (c *SearchCommand) Execute(args []string, opts GlobalOptions) error {
 		doc, err := reader.GetDocument(sourceDocID)
 		if err == nil {
 			highlights = buildHighlightsForDoc(doc, terms, highlighter)
+			docsForAgg = append(docsForAgg, doc)
 		}
 
 		hits = append(hits, SearchHit{
@@ -103,18 +111,24 @@ func (c *SearchCommand) Execute(args []string, opts GlobalOptions) error {
 		})
 	}
 
+	aggResult, err := aggregate.Build(docsForAgg, c.agg, c.group)
+	if err != nil {
+		ExitWithError(fmt.Errorf("聚合失败: %w", err))
+	}
+	showCount := c.agg != ""
+
 	// 输出结果
 	switch c.output {
 	case "json":
-		outputJSON(os.Stdout, hits)
+		outputJSON(os.Stdout, hits, aggResult, showCount)
 	default:
-		outputText(os.Stdout, hits)
+		outputText(os.Stdout, hits, aggResult, showCount)
 	}
 
 	return nil
 }
 
-func outputText(w *os.File, hits []SearchHit) {
+func outputText(w *os.File, hits []SearchHit, aggResult *aggregate.Result, showCount bool) {
 	fmt.Fprintf(w, "找到 %d 个结果:\n\n", len(hits))
 
 	for i, hit := range hits {
@@ -124,9 +138,21 @@ func outputText(w *os.File, hits []SearchHit) {
 			fmt.Fprintf(w, "    Highlight field=%s range=[%d,%d) fragment=%q\n", hl.Field, hl.Start, hl.End, hl.Fragment)
 		}
 	}
+
+	if aggResult != nil {
+		if showCount {
+			fmt.Fprintf(w, "\nAgg count=%d\n", aggResult.Count)
+		}
+		if len(aggResult.Buckets) > 0 {
+			fmt.Fprintln(w, "\nAgg buckets:")
+			for _, b := range aggResult.Buckets {
+				fmt.Fprintf(w, "  %s: %d\n", b.Key, b.Count)
+			}
+		}
+	}
 }
 
-func outputJSON(w *os.File, hits []SearchHit) {
+func outputJSON(w *os.File, hits []SearchHit, aggResult *aggregate.Result, showCount bool) {
 	fmt.Fprintf(w, `{"total":%d,"results":[`, len(hits))
 	for i, hit := range hits {
 		if i > 0 {
@@ -145,7 +171,30 @@ func outputJSON(w *os.File, hits []SearchHit) {
 		}
 		fmt.Fprintf(w, `}`)
 	}
-	fmt.Fprintf(w, "]}")
+	fmt.Fprintf(w, "]")
+	if aggResult != nil && (showCount || len(aggResult.Buckets) > 0) {
+		fmt.Fprintf(w, `,"aggregations":{`)
+		wrote := false
+		if showCount {
+			fmt.Fprintf(w, `"count":%d`, aggResult.Count)
+			wrote = true
+		}
+		if len(aggResult.Buckets) > 0 {
+			if wrote {
+				fmt.Fprintf(w, ",")
+			}
+			fmt.Fprintf(w, `"buckets":[`)
+			for i, b := range aggResult.Buckets {
+				if i > 0 {
+					fmt.Fprintf(w, ",")
+				}
+				fmt.Fprintf(w, `{"key":%q,"count":%d}`, b.Key, b.Count)
+			}
+			fmt.Fprintf(w, "]")
+		}
+		fmt.Fprintf(w, "}")
+	}
+	fmt.Fprintf(w, "}")
 }
 
 // CountCommand 统计命令。

--- a/cmd/maure/command/serve.go
+++ b/cmd/maure/command/serve.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strconv"
 
+	"maure/pkg/aggregate"
 	"maure/pkg/document"
 	"maure/pkg/highlight"
 	"maure/pkg/index"
@@ -127,6 +128,8 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	q := r.URL.Query().Get("q")
+	agg := r.URL.Query().Get("agg")
+	group := r.URL.Query().Get("group")
 	if q == "" {
 		http.Error(w, "缺少查询参数 q", http.StatusBadRequest)
 		return
@@ -146,6 +149,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 
 	terms := query.ExtractTerms(parsedQuery)
 	response := make([]SearchHit, 0, len(results))
+	docsForAgg := make([]*document.Document, 0, len(results))
 	for _, r := range results {
 		docID := r.DocID
 		if sourceDocID, ok := s.sourceDocID[r.DocID]; ok {
@@ -156,6 +160,7 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		doc, docErr := s.ctx.Reader.GetDocument(docID)
 		if docErr == nil {
 			highlights = buildHighlightsForDoc(doc, terms, s.highlighter)
+			docsForAgg = append(docsForAgg, doc)
 		}
 
 		response = append(response, SearchHit{
@@ -165,7 +170,33 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 		})
 	}
 
+	aggResult, err := aggregate.Build(docsForAgg, agg, group)
+	if err != nil {
+		http.Error(w, "聚合失败: "+err.Error(), http.StatusBadRequest)
+		return
+	}
+	showCount := agg != ""
+
 	w.Header().Set("Content-Type", "application/json")
+	if showCount || len(aggResult.Buckets) > 0 {
+		payload := map[string]interface{}{
+			"total":   len(response),
+			"results": response,
+		}
+		aggs := make(map[string]interface{})
+		if showCount {
+			aggs["count"] = aggResult.Count
+		}
+		if len(aggResult.Buckets) > 0 {
+			aggs["buckets"] = aggResult.Buckets
+		}
+		payload["aggregations"] = aggs
+		if err := json.NewEncoder(w).Encode(payload); err != nil {
+			http.Error(w, "encode error", http.StatusInternalServerError)
+		}
+		return
+	}
+
 	if err := json.NewEncoder(w).Encode(response); err != nil {
 		http.Error(w, "encode error", http.StatusInternalServerError)
 	}

--- a/pkg/aggregate/aggregate.go
+++ b/pkg/aggregate/aggregate.go
@@ -1,0 +1,143 @@
+package aggregate
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"maure/pkg/document"
+)
+
+const (
+	AggCount = "count"
+)
+
+// Bucket 是分组聚合桶。
+type Bucket struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// Result 是聚合结果。
+type Result struct {
+	Count   int      `json:"count,omitempty"`
+	Buckets []Bucket `json:"buckets,omitempty"`
+}
+
+// Build 计算 count/group 聚合。
+func Build(docs []*document.Document, agg string, group string) (*Result, error) {
+	result := &Result{}
+
+	if agg != "" && !strings.EqualFold(strings.TrimSpace(agg), AggCount) {
+		return nil, fmt.Errorf("unsupported agg: %s", agg)
+	}
+
+	if strings.EqualFold(strings.TrimSpace(agg), AggCount) {
+		result.Count = len(docs)
+	}
+
+	group = strings.TrimSpace(group)
+	if group == "" {
+		return result, nil
+	}
+
+	spec, err := parseGroupSpec(group)
+	if err != nil {
+		return nil, err
+	}
+
+	counts := make(map[string]int)
+	for _, doc := range docs {
+		if doc == nil {
+			continue
+		}
+		key := "(unknown)"
+		switch spec.kind {
+		case "field":
+			if field := doc.Get(spec.value); field != nil {
+				val := strings.TrimSpace(field.StringValue())
+				if val != "" {
+					key = val
+				}
+			}
+		case "time":
+			if field := doc.Get("timestamp"); field != nil {
+				if t, ok := parseTimestamp(field.StringValue()); ok {
+					bucketStart := t.Truncate(spec.window)
+					key = bucketStart.Format(time.RFC3339)
+				}
+			}
+		default:
+			return nil, fmt.Errorf("unsupported group kind: %s", spec.kind)
+		}
+		counts[key]++
+	}
+
+	result.Buckets = make([]Bucket, 0, len(counts))
+	for key, count := range counts {
+		result.Buckets = append(result.Buckets, Bucket{
+			Key:   key,
+			Count: count,
+		})
+	}
+	sort.Slice(result.Buckets, func(i, j int) bool {
+		if result.Buckets[i].Count == result.Buckets[j].Count {
+			return result.Buckets[i].Key < result.Buckets[j].Key
+		}
+		return result.Buckets[i].Count > result.Buckets[j].Count
+	})
+
+	return result, nil
+}
+
+type groupSpec struct {
+	kind   string
+	value  string
+	window time.Duration
+}
+
+func parseGroupSpec(group string) (*groupSpec, error) {
+	group = strings.TrimSpace(group)
+	if group == "" {
+		return nil, fmt.Errorf("group is empty")
+	}
+
+	if strings.HasPrefix(strings.ToLower(group), "time(") && strings.HasSuffix(group, ")") {
+		windowText := strings.TrimSpace(group[len("time(") : len(group)-1])
+		window, err := time.ParseDuration(windowText)
+		if err != nil || window <= 0 {
+			return nil, fmt.Errorf("invalid time group window: %s", windowText)
+		}
+		return &groupSpec{
+			kind:   "time",
+			window: window,
+		}, nil
+	}
+
+	return &groupSpec{
+		kind:  "field",
+		value: group,
+	}, nil
+}
+
+func parseTimestamp(ts string) (time.Time, bool) {
+	ts = strings.TrimSpace(ts)
+	if ts == "" {
+		return time.Time{}, false
+	}
+	layouts := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.000",
+		"2006-01-02 15:04:05,000",
+		"2006-01-02 15:04:05",
+	}
+	for _, layout := range layouts {
+		t, err := time.Parse(layout, ts)
+		if err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}

--- a/pkg/aggregate/aggregate_test.go
+++ b/pkg/aggregate/aggregate_test.go
@@ -1,0 +1,65 @@
+package aggregate
+
+import (
+	"testing"
+
+	"maure/pkg/document"
+)
+
+func TestBuildCountOnly(t *testing.T) {
+	docs := []*document.Document{
+		document.NewDocumentWithValues("1", map[string]interface{}{"message": "a"}),
+		document.NewDocumentWithValues("2", map[string]interface{}{"message": "b"}),
+	}
+	result, err := Build(docs, "count", "")
+	if err != nil {
+		t.Fatalf("build count failed: %v", err)
+	}
+	if result.Count != 2 {
+		t.Fatalf("expected count 2, got %d", result.Count)
+	}
+}
+
+func TestBuildGroupByField(t *testing.T) {
+	doc1 := document.NewDocument()
+	doc1.Add(document.NewStringField("level", "INFO"))
+	doc2 := document.NewDocument()
+	doc2.Add(document.NewStringField("level", "ERROR"))
+	doc3 := document.NewDocument()
+	doc3.Add(document.NewStringField("level", "ERROR"))
+
+	result, err := Build([]*document.Document{doc1, doc2, doc3}, "", "level")
+	if err != nil {
+		t.Fatalf("build group by field failed: %v", err)
+	}
+	if len(result.Buckets) != 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(result.Buckets))
+	}
+	if result.Buckets[0].Key != "ERROR" || result.Buckets[0].Count != 2 {
+		t.Fatalf("unexpected first bucket: %+v", result.Buckets[0])
+	}
+}
+
+func TestBuildGroupByTime(t *testing.T) {
+	doc1 := document.NewDocument()
+	doc1.Add(document.NewStringField("timestamp", "2026-02-10T10:01:00Z"))
+	doc2 := document.NewDocument()
+	doc2.Add(document.NewStringField("timestamp", "2026-02-10T10:04:59Z"))
+	doc3 := document.NewDocument()
+	doc3.Add(document.NewStringField("timestamp", "2026-02-10T10:08:00Z"))
+
+	result, err := Build([]*document.Document{doc1, doc2, doc3}, "", "time(5m)")
+	if err != nil {
+		t.Fatalf("build group by time failed: %v", err)
+	}
+	if len(result.Buckets) != 2 {
+		t.Fatalf("expected 2 buckets, got %d", len(result.Buckets))
+	}
+}
+
+func TestBuildInvalidGroupWindow(t *testing.T) {
+	_, err := Build([]*document.Document{}, "", "time(bad)")
+	if err == nil {
+		t.Fatalf("expected invalid group window error")
+	}
+}


### PR DESCRIPTION
## Summary

This PR adds real-time aggregation capabilities to search results, without introducing DSL.

Supported aggregations:

- `--agg=count` / `?agg=count`
- `--group=<field>` / `?group=<field>` (e.g. `level`)
- `--group=time(<window>)` / `?group=time(<window>)` (e.g. `time(5m)`)

## Changes

### 1) Aggregation core package

Added `pkg/aggregate`:

- `pkg/aggregate/aggregate.go`
- `pkg/aggregate/aggregate_test.go`

Capabilities:
- Count aggregation
- Group-by field aggregation
- Group-by time window aggregation
- Input validation for unsupported agg/group settings

### 2) CLI search integration

Updated:
- `cmd/maure/command/search.go`

Behavior:
- Existing search result behavior is preserved.
- When aggregation params are provided, CLI output appends:
  - `Agg count=...`
  - `Agg buckets: ...`
- JSON output appends:
  - `"aggregations": {"count": ..., "buckets": [...]}` (when requested)

### 3) HTTP search integration

Updated:
- `cmd/maure/command/serve.go`

Behavior:
- Existing `/search?q=...` response remains compatible.
- When `agg` or `group` is provided, response includes:
  - `total`
  - `results`
  - `aggregations`

## Examples

CLI:
```bash
maure search --agg=count "error OR warn"
maure search --group=level "error OR warn"
maure search --group='time(5m)' "error OR warn"
